### PR TITLE
update PR matklad#185 to 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -
 
+## 1.12.1
+
+- Remove incorrect `debug_assert`.
+
 ## 1.12.0
 
 - Add `OnceCell::wait`, a blocking variant of `get`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -
 
+## 1.13.0
+
+- Add `Lazy::get`, similar to `OnceCell::get`.
+
 ## 1.12.1
 
 - Remove incorrect `debug_assert`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "once_cell"
-version = "1.12.1"
+version = "1.13.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/src/imp_pl.rs
+++ b/src/imp_pl.rs
@@ -168,6 +168,7 @@ fn initialize_inner(state: &AtomicU8, init: &mut dyn FnMut() -> bool) {
                     None,
                 );
             },
+            Err(INCOMPLETE) => (),
             Err(_) => debug_assert!(false),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,6 +741,23 @@ pub mod unsync {
                 None => panic!("Lazy instance has previously been poisoned"),
             })
         }
+
+        /// Gets the reference to the result of this lazy value if
+        /// it was initialized, otherwise returns `None`.
+        ///
+        /// # Example
+        /// ```
+        /// use once_cell::unsync::Lazy;
+        ///
+        /// let lazy = Lazy::new(|| 92);
+        ///
+        /// assert_eq!(Lazy::get(&lazy), None);
+        /// assert_eq!(&*lazy, &92);
+        /// assert_eq!(Lazy::get(&lazy), Some(&92));
+        /// ```
+        pub fn get(this: &Lazy<T, F>) -> Option<&T> {
+            this.cell.get()
+        }
     }
 
     impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
@@ -1213,6 +1230,23 @@ pub mod sync {
                 Some(f) => f(),
                 None => panic!("Lazy instance has previously been poisoned"),
             })
+        }
+
+        /// Gets the reference to the result of this lazy value if
+        /// it was initialized, otherwise returns `None`.
+        ///
+        /// # Example
+        /// ```
+        /// use once_cell::sync::Lazy;
+        ///
+        /// let lazy = Lazy::new(|| 92);
+        ///
+        /// assert_eq!(Lazy::get(&lazy), None);
+        /// assert_eq!(&*lazy, &92);
+        /// assert_eq!(Lazy::get(&lazy), Some(&92));
+        /// ```
+        pub fn get(this: &Lazy<T, F>) -> Option<&T> {
+            this.cell.get()
         }
     }
 


### PR DESCRIPTION
This branch merges upstream's `master` branch into PR matklad#185.

I need to patch a dependency on `once_cell` that needs at least 1.13.0 to pick up the provenance fix, but you may want to actually merge this into the PR as well.